### PR TITLE
[Sqlite] load current schema directly from sqlite_schema table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bhoos/migration",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "description": "Bhoos Database Migration Support Library",
   "main": "es6/index.js",

--- a/src/db/Sqlite.ts
+++ b/src/db/Sqlite.ts
@@ -50,10 +50,11 @@ export class SqliteColumn extends ColumnBase {
   }
 
   alterSQL(obj: { [name: string]: any }): string[] {
+    const newObj = { name : this.name, dataType: this.dataType, nullable : this.nullable, autoIncrement : this.autoIncrement};
     console.log(
-      `altering column:\n\tOld: ${this.name} ${this.dataType} ${
-        this.nullable
-      }\n\tNew: ${JSON.stringify(obj)}`,
+      `altering column:
+\tOld: ${JSON.stringify(obj)}
+\tNew: ${JSON.stringify(newObj)}`,
     );
     const res: string[] = [];
     if (this.dataType !== obj.dataType) {
@@ -67,7 +68,7 @@ Also: Don't stress. sqlite tables are dynamically typed. so your code would work
     }
 
     if (this.nullable !== Boolean(obj.nullable)) {
-      console.error('Cannot change NULLability of a column');
+      console.error('Cannot change NULLability of a column ' + obj.name + ' of table ' + this.table.name);
     }
 
     if (this.defaultValue !== obj.defaultValue) {
@@ -97,6 +98,9 @@ export class SqliteTable extends TableBase {
       const { create, alter, drop } = seggregate(this[cc], newTable[cc]);
 
       create.forEach(item => {
+        if (cc == 'constraints') {
+          throw new Error('Sqlite doesnot support adding constraints' + item.name);
+        }
         changes.push(alterTable + 'ADD ' + item.createSQL());
       });
 

--- a/src/drivers/parsingUtils.ts
+++ b/src/drivers/parsingUtils.ts
@@ -1,0 +1,260 @@
+import assert from "assert";
+
+export type Cursor = {
+  str: string;
+  pos: number;
+  match: string | false;
+};
+
+function copyCursor(cur: Cursor) {
+  return { str : cur.str , pos: cur.pos , match : cur.match};
+}
+
+function copyCursorInto(into : Cursor, fromm : Cursor) {
+  into.str = fromm.str;
+  into.pos = fromm.pos;
+  into.match  = fromm.match;
+  return into;
+}
+
+function isWhiteSpaceChar(char : string) {
+  const isws = (char === " "  || char === "\n" || char === "\r" || char === "\t");
+  return isws;
+}
+
+export function consumeEnclosedBy(cur: Cursor, startChar: string, endChar: string) {
+  // the case where startChar == endChar is tricky. Be aware of that.
+  let count = 0;
+  let startPos = null;
+  let endPos = cur.pos;
+  for (let i = cur.pos; i < cur.str.length; i++) {
+    const char = cur.str[i];
+    if (char === startChar) {
+      if (char === endChar && count != 0) {
+        endPos = i; break;
+      }
+      if (count === 0) startPos = i + 1;
+      count++;
+    } else if (char === endChar) {
+      count--;
+      if (count === 0) {
+        endPos = i;
+        break;
+      }
+    } else if (startPos === null && !isWhiteSpaceChar(char)) {
+      cur.match = '';
+      break;
+    }
+  }
+  if (startPos != null)
+    cur.pos = endPos +1;
+  cur.match = startPos ? cur.str.substring(startPos, endPos) : false;
+}
+
+export function matchRegExp(cur: Cursor, regExp: RegExp, group: number = 0) {
+  regExp.lastIndex = cur.pos;
+  const match = regExp.exec(cur.str);
+  if (match)
+    cur.pos = regExp.lastIndex;
+  cur.match = match ? match[group] : false;
+  return cur;
+}
+
+export function consumeSpaces(cur:Cursor) {
+  return matchRegExp(cur, /\s*/g);
+}
+
+export function consumeCommaAndSpaces(cur: Cursor) {
+  for (let i = cur.pos; i < cur.str.length; i++) {
+    const char = cur.str[i];
+    if (isWhiteSpaceChar(char)) {
+    } else if (char === ",") {
+      cur.pos = i+1;
+      return;
+    } else {
+      return;
+    }
+  }
+}
+
+export function consumeAlphabets(cur: Cursor) {
+  return matchRegExp(cur, /\s*([A-z]*)/g, 1);
+}
+
+export function consumeWord(cur : Cursor, word : string, caseSensitive : boolean = false){
+  consumeAlphabets(cur);
+  assert(cur.match);
+  if (caseSensitive) {
+    assert(cur.match === word);
+  } else {
+    assert(cur.match.toLowerCase() === word.toLowerCase());
+  }
+  return cur;
+}
+
+
+export function getMatch(cur: Cursor, func : (c : Cursor) => any){
+  let error = null;
+  try {
+    func(cur)
+  } catch (err) {
+    cur.match == null
+    error = err;
+  }
+  if (!cur.match) {
+    throw new Error('Failed to get match for ' + func.name + ' at cursor ' + JSON.stringify(cur) + '\n Error is ' + JSON.stringify(error));
+  }
+  return cur.match;
+}
+
+export function consumeNameInsideBrackets(cur : Cursor) {
+  const _name = getMatch(cur, (cur) => consumeEnclosedBy(cur, "(", ")"));
+  const name = getMatch({str : _name, pos: 0, match : null}, consumePgName);
+  return name;
+}
+export function consumeValue(cur : Cursor) {
+  // TODO: doesn't support all kinds of expressions
+  // check https://www.postgresql.org/docs/current/sql-createfunction.html #default_expr
+  consumeEnclosedBy(cur, "(", ")");
+  if (cur.match != "") return cur;
+  return matchRegExp(cur, /\s*([A-z0-9_])/g, 1);
+}
+
+export function consumePgName(cur: Cursor) {
+  // From: https://www.postgresql.org/docs/7.0/syntax525.htm
+  // Names in SQL must begin with a letter (a-z) or underscore (_).
+  // Subsequent characters in a name can be letters, digits (0-9), or underscores
+  // Names containing other characters may be formed by surrounding them with double quotes (").
+  // For example, table or column names may contain otherwise disallowed characters such as spaces, ampersands, etc. if quoted.
+  consumeEnclosedBy(cur, '"', '"');
+  if (cur.match != "") {
+    return cur; // string enclosed by "s is a pg name
+  } else {
+    consumeSpaces(cur);
+    return matchRegExp(cur, /([A-z_][A-z_0-9]*)/g, 1);
+  }
+}
+
+export function consumeTypeName(cur:Cursor) {
+  // https://www.postgresql.org/docs/current/datatype.html
+  consumePgName(cur);
+  if (!cur.match) throw new Error(`Type of not specified at pos ${cur.pos}`);
+  const lcase = cur.match.toLowerCase();
+  if (lcase === "character" || lcase === "bit") {
+    const backup = copyCursor(cur);
+    consumeAlphabets(cur);
+    if (cur.match.toLowerCase() === "varying") {
+      consumeEnclosedBy(cur, "(", ")");
+      cur.match = lcase + " varying";
+      return;
+    } else {
+      consumeEnclosedBy(cur, "(", ")");
+      return copyCursorInto(cur, backup);
+    }
+  } else if (lcase === "double") {
+    consumeAlphabets(cur);
+    if (cur.match != "precision") throw new Error(`There is no type called 'double'. You probably mean 'double precision'`);
+    consumeEnclosedBy(cur, "(", ")");
+    cur.match = "double precision";
+    return;
+  } else if (lcase === "time" || lcase === "timestamp") {
+    consumeEnclosedBy(cur, "(", ")"); // ignore timestamp miliseconds precision
+    if (cur.match)
+      console.error("Ignoring timestamp precision", cur.match, 'at', cur.pos);
+
+    matchRegExp(cur, /\s*without\s*time\s*zone/gi);
+    if (cur.match) {
+      cur.match = lcase;
+      return;
+    }
+    matchRegExp(cur, /\s*with\s*time\s*zone/gi);
+    if (cur.match){
+      cur.match = lcase+'tz'; // timetz or timestamptz
+      return;
+    }
+    cur.match = lcase;
+    return;
+  } else if (lcase === "numeric" || lcase === "interval") {
+    consumeEnclosedBy(cur, "(", ")"); // ignore timestamp miliseconds precision
+    if (cur.match)
+      console.error("Ignoring ${lcase} presion", cur.match, 'at', cur.pos);
+    cur.match = lcase;
+    return;
+  } else if (lcase === 'interval') {
+    throw new Error('Cannot handle `interval` type');
+  }
+
+  let typeName = cur.match;
+  consumeEnclosedBy(cur, "(", ")"); // ignore () e.g. varchar(32)
+  matchRegExp(cur, /(\s*\[\])*/g); // capture array spec.
+  if (cur.match)
+    typeName = typeName + cur.match;
+  cur.match = typeName;
+}
+
+export function debugCursor(cur: Cursor, message : string = '') {
+  console.log(`\n${message} Cursor pos:`, cur.pos, " match: ", cur.match);
+  for (let i = 0; i < cur.str.length; i++) {
+    if (i === cur.pos) {
+      process.stdout.write("[[");
+    }
+    process.stdout.write(cur.str[i]);
+    if (i === cur.pos) {
+      process.stdout.write("]]");
+    }
+  }
+}
+
+export function consumeCommentIfExists(cur: Cursor, ignoreChars : string = ',') {
+  let endPos = cur.str.length-1;
+  let comment = false;
+  let startPos = 0;
+  for (let i = cur.pos; i < cur.str.length; i++) {
+    const char = cur.str[i];
+    if (char === '\n' || char === '\r') {
+      endPos = i;
+      break;
+    } else if (char == '-') {
+      comment = true;
+    } else if (!isWhiteSpaceChar(char) && !ignoreChars.includes(char)) {
+      if (!comment) {
+        break;
+      }
+      if (startPos === 0) {
+        startPos = i;
+      }
+    }
+  }
+  if (startPos != 0) {
+    const match = cur.str.substring(startPos, endPos);
+    cur.pos = endPos + 1;
+    consumeCommentIfExists(cur);
+    cur.match = match + (cur.match ? `\n${cur.match}` : '');
+  } else {
+    cur.match = false;
+  }
+  return cur;
+}
+
+export function consumeDefaultValIfExists(cur: Cursor) {
+  const pos = cur.pos;
+  consumeAlphabets(cur);
+  if (cur.match && cur.match.toLocaleLowerCase() === 'default') {
+    const defaultValue = consumeValue(cur).match;
+    return defaultValue;
+  } else {
+    cur.pos = pos;
+  }
+}
+
+// Run a function `f` that moves the cursor `cur` until it returs null.
+// collect and return all the function return values
+export function collectUntillNull<T>(cur: Cursor, f: (c: Cursor) => T): T[] {
+  let result: T[] = [];
+  let r;
+  do {
+    r = f(cur);
+    if (r) result.push(r);
+  } while (r);
+  return result;
+}

--- a/src/drivers/sqlite.ts
+++ b/src/drivers/sqlite.ts
@@ -1,5 +1,98 @@
 import { Driver, EntityObject } from './Driver.js';
 import { Database } from 'sqlite';
+import { collectUntillNull, consumeAlphabets, consumeEnclosedBy, consumeNameInsideBrackets, consumePgName, consumeTypeName, consumeWord, Cursor, getMatch } from './parsingUtils.js';
+import assert from 'assert';
+
+type SqliteSchema = {
+  type : string,
+  name : string,
+  tbl_name : string,
+  sql : string
+}
+
+function parseConstraint(cur : Cursor) {
+  const name = getMatch(cur, consumePgName);
+  const type = getMatch(cur, consumeAlphabets).toUpperCase();
+  if (type === 'FOREIGN') {
+    consumeWord(cur, "KEY")
+    const column = consumeNameInsideBrackets(cur);
+    consumeWord(cur, "REFERENCES")
+    const refTable = getMatch(cur, consumePgName);
+    const refColumn = consumeNameInsideBrackets(cur);
+    return {
+      name, column, refTable, refColumn
+    }
+  } else if (type === 'PRIMARY'){
+    consumeWord(cur, "KEY")
+    const enclosedStr = getMatch(cur, (cur) => consumeEnclosedBy(cur, "(", ")"));
+    const columns = collectUntillNull(
+      {str: enclosedStr, pos : 0 , match : null},
+      (cur) => {consumePgName(cur); return cur.match}
+    );
+    return {
+      name, columns
+    }
+  } else {
+    throw new Error('Unknown constraint type');
+  }
+}
+
+function parseColumn(cur : Cursor, columnName : string) {
+  const dataType = getMatch(cur, consumeTypeName);
+  // maybe null
+  let nullable = true;
+  consumeAlphabets(cur);
+  if (cur.match) {
+    if (cur.match.toLowerCase() === 'null') {
+      nullable = true;
+    } else {
+      assert(cur.match.toLowerCase() === 'not')
+      consumeWord(cur, 'NULL');
+      nullable = false;
+    }
+  }
+  return {
+    name : columnName,
+    dataType,
+    nullable
+  }
+}
+
+function parseTableSchema(sql: string) {
+  let cur : Cursor = { str : sql , pos : 0 , match : null}
+
+  // Table Name
+  consumeWord(cur, 'CREATE')
+  consumeWord(cur, 'TABLE')
+  const tableName = getMatch(cur, consumePgName);
+
+  // Table Definition
+  consumeEnclosedBy(cur, "(", ")");
+  assert(cur.match)
+  let columns  = [];
+  let constraints  = [];
+  for (const entry of cur.match.split(",")){
+    cur = {str : entry, pos:0 , match: null}
+    consumePgName(cur);
+    assert(cur.match);
+    if (cur.match.toLowerCase() === 'constraint') {
+      constraints.push(parseConstraint(cur));
+    } else {
+      const columnName = cur.match;
+      columns.push(parseColumn(cur, columnName));
+    }
+  }
+
+  return {
+    "__type" : "table",
+    "name" : tableName,
+    "isCheckPoint" : false,
+    "columns" : columns,
+    "constraints" : constraints
+  };
+}
+
+
 // Note:
 // Support for the RETURNING clause came with version 3.35.0. (https://sqlite.org/releaselog/3_35_0.html)
 // so make sure the sqlite library you use supports that. (sqlite3 > 5.0.0 works)
@@ -13,29 +106,21 @@ export class SqliteDriver implements Driver {
     this.migrationTable = migrationTable;
   }
 
-  async load() {
-     await this.run(`CREATE TABLE IF NOT EXISTS "${this.migrationTable}"(
-      id INTEGER NOT NULL,
-      timestamp INTEGER NOT NULL,
-      entities TEXT,
-      records TEXT,
-      PRIMARY KEY ("id" AUTOINCREMENT)
-    )`);
-    const res = await this.run<{ version: number }>(
-      `SELECT MAX(id) as version FROM "${this.migrationTable}"`
-    );
-    const version = res[0].version || 0;
-    if (version === 0) {
-      return { version: 0, entities: [], records: []};
-    }
 
-    const data = await this.run<{ entities: string, records: string}>(
-      `SELECT entities, records FROM "${this.migrationTable}" WHERE id=${version}`);
-    return {
-      version,
-      entities: JSON.parse(data[0].entities) as Array<EntityObject>,
-      records: JSON.parse(data[0].records) as Array<string>,
-    };
+  async load() {
+    let tableSchemaSqls = await this.run<SqliteSchema>(`SELECT * from sqlite_schema where "type" = 'table';`);
+    tableSchemaSqls = tableSchemaSqls.filter((t) =>
+      t.name != this.migrationTable &&
+      t.name != 'sqlite_sequence');
+
+    let version = await this.run<{version : number}>(`SELECT MAX(id) as version FROM "${this.migrationTable}"`);
+    const tables = tableSchemaSqls.map((r) => parseTableSchema(r.sql));
+    const schema = {
+      version : version[0].version,
+      entities: tables,
+      records : []
+    }
+    return schema;
   }
 
   async run<T extends object={}>(sql: string): Promise<Array<T>> {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,11 +1,16 @@
 import { DatabaseBase } from "./base/Database.js";
 import { Database } from "./types.js";
 
-export async function migrate(db: DatabaseBase, migration: (db: Database) => void) {
+export async function migrate(db: DatabaseBase,
+                              migration: (db: Database) => void,
+                              preMigration? : () => Promise<void>,
+                              postMigration? : () => Promise<void>) {
   // Perform the entire migration within a transaction
   await db.begin();
-
+  if (preMigration)
+    await preMigration();
   // Run the migration function
+  //   migration function defines the db schema required.
   migration(db);
   
   // Get the migration sql
@@ -16,6 +21,7 @@ export async function migrate(db: DatabaseBase, migration: (db: Database) => voi
   // Run all the migrations
   await db.migrate(version, queries);
 
+  if (postMigration)
+    await postMigration();
   await db.commit();
 }
-


### PR DESCRIPTION
Fixes #

## Checklist 

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if necessary)
- [ ] I have performed adequate tests that prove my fix is effective or that my feature works

## Proposed Changes
- For sqlite, schema is directly read from `sqlite_schema` table instead of relying on the json stored in `migrations` table. 

- The entry function `migrate` now  takes two additional optional parameters: preMigration, and postMigration. 
   This was done because there are many instances where db changes in addition to schema changes would be necessary. And since in sqlite, transactions can't be nested, the only choice during migration would be to wrap pre-migration, schema changes and post-migration with separate transaction blocks. This is not good, and hence the change.
